### PR TITLE
fix class name after visual blip update

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Builder Addictions",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "manifest_version": 2,
     "description": "Extensão para facilitar a visualização das funcionalidades do Blip Builder.",
     "icons": {

--- a/src/content/features/configurations/ConfigurationManager.ts
+++ b/src/content/features/configurations/ConfigurationManager.ts
@@ -31,7 +31,6 @@ export default class ConfigurationManager extends FeatureBase {
         const res = await fetch(Utils.getUrl("resources/menuActionButton.html"));
         const html = await res.text();
 
-        // const iconButtonList = document.querySelector(".icon-button-list");
         const iconButtonList = document.querySelector(".builder-icon-button-list");
         const addictionsButton = document.createElement("li");
 

--- a/src/content/features/configurations/ConfigurationManager.ts
+++ b/src/content/features/configurations/ConfigurationManager.ts
@@ -31,7 +31,8 @@ export default class ConfigurationManager extends FeatureBase {
         const res = await fetch(Utils.getUrl("resources/menuActionButton.html"));
         const html = await res.text();
 
-        const iconButtonList = document.querySelector(".icon-button-list");
+        // const iconButtonList = document.querySelector(".icon-button-list");
+        const iconButtonList = document.querySelector(".builder-icon-button-list");
         const addictionsButton = document.createElement("li");
 
         addictionsButton.id = "addictions-menu-button";


### PR DESCRIPTION
the class "icon-button-list" which was used to attach the builder additions was renamed to "builder-icon-button-list"